### PR TITLE
fix: indentation error in ci.yml (Lint job)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
 
          steps:
            - uses: actions/checkout@v4
-            - name: Set up Python
-              uses: actions/setup-python@v5
-              with:
-                python-version: "3.11"
+           - name: Set up Python
+             uses: actions/setup-python@v5
+             with:
+               python-version: "3.11"
 
-            - name: Install ruff
-              run: pip install ruff>=0.4.0
+           - name: Install ruff
+             run: pip install ruff>=0.4.0
 
-            - name: Run ruff
-              run: ruff check .
+           - name: Run ruff
+             run: ruff check .


### PR DESCRIPTION
## Changes
- Corrected indentation for Lint job in `.github/workflows/ci.yml`