### PR TITLE
fix: expand ~ in snapshot_dir path

### DIFF
--- a/logsnap/config_cmd.py
+++ b/logsnap/config_cmd.py
@@ -25,7 +25,7 @@ def init() -> None:
 
     snapshot_dir: str = typer.prompt(
         "Directory in which to store logsnap snapshots.",
-        default="~/.config/logsnap/logsnap_snapshots/",
+        default="~/logsnap_snapshots/",
     )
 
     default_format: str = typer.prompt(

--- a/logsnap/snapshot.py
+++ b/logsnap/snapshot.py
@@ -58,7 +58,7 @@ def run_snap(
     session_path: Path = SESSION_PATH,
 ) -> None:
     fmt = format_override or config.default_format
-    snapshot_dir = Path(config.snapshot_dir)
+    snapshot_dir = Path(config.snapshot_dir).expanduser()
     snapshot_dir.mkdir(parents=True, exist_ok=True)
 
     snapshot_filename = (


### PR DESCRIPTION
## What
Expanded ~ in snapshot_dir before creating snapshot path.

## Changes
- Changed default snapshot_dir location to `~/logsnap_snapshots`
- Used expanduser() to make snapshot_dir point to 
  `/home/user/logsnap_snapshots`

## Why
So that snapshots are created at `/home/user/logsnap_snapshots`
rather than at `./'~`/logsnap_snapshots`

## Impact 
Snapshots are created at `/home/user/logsnap_snapshots`.

## Checklist
- [x] Closes #20 