### PR TITLE
Fix: link formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ contribution guidelines.
 
 ## Architecture decisions
 All architectural decisions are documented in 
-[docs/adr] (docs/adr).
+[docs/adr](docs/adr).
 
 ## License
 


### PR DESCRIPTION
Fixed link formatting in README to ensure that link to `docs/adr` works.