### PR TITLE
fix: branch naming conventions to appear correctly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 ## Branch Naming
 
-- feat/<short-description>
-- fix/<short-description>
-- chore/<short-description>
-- docs/<short-description>
+- `feat/<short-description>`
+- `fix/<short-description>`
+- `chore/<short-description>`
+- `docs/<short-description>`
 
 ## Commit Messages
 


### PR DESCRIPTION
Use of `<>` caused errors in branch naming conventions section
rendering. Fixed in this PR.