### PR TITLE
feat: enable no_args_is_help=True in typer configuration

### DIFF
--- a/logsnap/main.py
+++ b/logsnap/main.py
@@ -13,7 +13,7 @@ class OutputFormat(str, Enum):
     jsonl = "jsonl"
 
 
-app = typer.Typer()
+app = typer.Typer(name="logsnap", no_args_is_help=True)
 app.add_typer(config_app)
 
 


### PR DESCRIPTION
## What
Enabled automatic help output by setting `no_args_is_help=True` on 
the Typer app instance.

## Changes
- `main.py`: set `no_args_is_help=True` when initializing 
  `typer.Typer()`

## Why
`no_args_is_help` is the idiomatic way to handle this use case with
`Typer`. It requires minimal code changes while providing better UX
for users discovering the tool.

## Impact
- No breaking changes
- Help text automatically displayed for users unfamiliar with the 
  tool

## Checklist
- [x] CI green
- [x] All tests pass